### PR TITLE
Fixes broken link to marked library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 marked-element
 ==============
 
-Element wrapper for the [marked](http://marked.org/) library.
+Element wrapper for the [marked](https://github.com/chjj/marked) library.
 
 `<marked-element>` accepts Markdown source either via its `markdown` attribute:
 


### PR DESCRIPTION
http://marked.org/ doesn't seem to exist, switched it out for a link to the github repo.
