### PR TITLE
Change Marked url to project page. Closes #8

### DIFF
--- a/marked-element.html
+++ b/marked-element.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="marked-import.html">
 
 <!--
-Element wrapper for the [marked](http://marked.org/) library.
+Element wrapper for the [marked](https://github.com/chjj/marked) library.
 
 `<marked-element>` accepts Markdown source either via its `markdown` attribute:
 


### PR DESCRIPTION
This commit introduces the change to Marked project url used
in documentation to point to the project url - similar to changes
of the http://git.io/vLfbG commit

Thanks!
