### PR TITLE
fix styling by rendering to a light child element

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       margin-bottom: 10px;
     }
 
+    .markdown-html.custom p {
+      padding-left: 24px;
+    }
+
   </style>
 </head>
 
@@ -53,6 +57,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <section>
       <h3>Inline Text</h3>
       <marked-element>
+        <div class="markdown-html"></div>
         <script type="text/markdown">
           ## Markdown Renderer
 
@@ -72,8 +77,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </section>
 
     <section>
-      <h3>Text via Attribute</h3>
-      <marked-element markdown="***Bold and italic***"></marked-element>
+      <h3>Text via Attribute, with custom styling</h3>
+      <marked-element markdown="***Bold and italic***">
+        <div class="markdown-html custom"></div>
+      </marked-element>
     </section>
 
   </div>

--- a/marked-element.html
+++ b/marked-element.html
@@ -13,13 +13,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
 Element wrapper for the [marked](https://github.com/chjj/marked) library.
 
-`<marked-element>` accepts Markdown source either via its `markdown` attribute:
+`<marked-element>` accepts Markdown source, and renders it to a child
+element with the class `markdown-html`. This child element can be styled
+as you would a normal DOM element. If you do not provide a child element
+with the `markdown-html` class, the Markdown source will still be rendered,
+but to a shadow DOM child that cannot be styled.
 
-    <marked-element markdown="`Markdown` is _awesome_!"></marked-element>
+The Markdown source can be specified either via the `markdown` attribute:
+
+    <marked-element markdown="`Markdown` is _awesome_!">
+      <div class="markdown-html"></div>
+    </marked-element>
 
 Or, you can provide it via a `<script type="text/markdown">` element child:
 
     <marked-element>
+      <div class="markdown-html"></div>
       <script type="text/markdown">
         Check out my markdown!
 
@@ -36,15 +45,34 @@ Or, you can provide it via a `<script type="text/markdown">` element child:
 
 Note that the `<script type="text/markdown">` approach is _static_. Changes to
 the script content will _not_ update the rendered markdown!
+
+### Styling
+If you are using a child with the `markdown-html` class, you can style it
+as you would a regular DOM element:
+
+    .markdown-html p {
+      color: red;
+    }
+
+    .markdown-html td:first-child {
+      padding-left: 24px;
+    }
+
 @element marked-element
 @group Molecules
 @hero hero.svg
 @demo demo/index.html
 -->
 <dom-module id="marked-element">
-
   <template>
-    <div id="content"></div>
+    <style>
+      /* Thanks IE 10. */
+      .hidden {
+        display: none !important;
+      }
+    </style>
+    <content select=".markdown-html"></content>
+    <div id="content" class="hidden"></div>
   </template>
 
 </dom-module>
@@ -93,11 +121,22 @@ the script content will _not_ update the rendered markdown!
      */
     attached: function() {
       this._attached = true;
+      this._outputElement = this.outputElement;
       this.render();
     },
 
     detached: function() {
       this._attached = false;
+    },
+
+    get outputElement () {
+      var child = Polymer.dom(this).queryDistributedElements('.markdown-html')[0];
+
+      if (child)
+        return child;
+
+      this.toggleClass('hidden', false, this.$.content);
+      return this.$.content;
     },
 
     /**
@@ -112,11 +151,11 @@ the script content will _not_ update the rendered markdown!
     render: function() {
       if (!this._attached) return;
       if (!this.markdown) {
-        this.$.content.innerHTML = '';
+        this._outputElement.innerHTML = '';
         return;
       }
 
-      this.$.content.innerHTML = marked(this.markdown, {
+      this._outputElement.innerHTML = marked(this.markdown, {
         highlight: this._highlight.bind(this),
       });
     },

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -27,6 +27,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="CamelCaseHTML">
     <template>
       <marked-element>
+        <div id="output" class="markdown-html"></div>
         <script type="text/markdown">
 ```html
 <div camelCase></div>
@@ -37,6 +38,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <test-fixture id="BadHTML">
+    <template>
+      <marked-element>
+        <div id="output" class="markdown-html"></div>
+        <script type="text/markdown">
+```html
+<p><div></p></div>
+```
+        </script>
+      </marked-element>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="CamelCaseHTMLWithoutChild">
+    <template>
+      <marked-element>
+        <script type="text/markdown">
+```html
+<div camelCase></div>
+```
+        </script>
+      </marked-element>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="BadHTMLWithoutChild">
     <template>
       <marked-element>
         <script type="text/markdown">
@@ -51,6 +77,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     'use strict';
 
+    // Thanks IE10.
+    function isHidden(element) {
+      var rect = element.getBoundingClientRect();
+      return (rect.width == 0 && rect.height == 0);
+    }
+
     // Replace reserved HTML characters with their character entity equivalents to match the
     // transform done by Markdown.
     //
@@ -62,19 +94,81 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return span.innerHTML;
     }
 
-    suite('<marked-element>', function() {
+    suite('<marked-element> with .markdown-html child', function() {
 
-      suite('respsects camelCased HTML', function() {
+      suite('respects camelCased HTML', function() {
+        var markedElement;
+        var proofElement;
+        var outputElement;
+
+        setup(function() {
+          markedElement = fixture('CamelCaseHTML');
+          proofElement = document.createElement('div');
+          outputElement = document.getElementById('output');
+        });
+
+        test('in code blocks', function() {
+          proofElement.innerHTML = '<div camelCase></div>';
+          expect(outputElement).to.equal(markedElement.outputElement);
+          expect(isHidden(markedElement.$.content)).to.be.true;
+
+          // If Markdown content were put into a `<template>` or directly into the DOM, it would be
+          // rendered as DOM and be converted from camelCase to lowercase per HTML parsing rules. By
+          // using `<script>` descendants, content is interpreted as plain text.
+          expect(proofElement.innerHTML).to.eql('<div camelcase=""></div>')
+          expect(outputElement.innerHTML).to.include(escapeHTML('<div camelCase>'));
+        });
+      });
+
+      suite('respects bad HTML', function() {
+        var markedElement;
+        var proofElement;
+        var outputElement;
+
+        setup(function() {
+          markedElement = fixture('BadHTML');
+          proofElement = document.createElement('div');
+          outputElement = document.getElementById('output');
+        });
+
+        test('in code blocks', function() {
+          proofElement.innerHTML = '<p><div></p></div>';
+          expect(outputElement).to.equal(markedElement.outputElement);
+          expect(isHidden(markedElement.$.content)).to.be.true;
+
+          // If Markdown content were put into a `<template>` or directly into the DOM, it would be
+          // rendered as DOM and close unbalanced tags. Because they are in code blocks they should
+          // remain as typed.
+          // Turns out, however IE and everybody else have slightly different opinions
+          // about how the incorrect HTML should be fixed. It seems that:
+          // IE says:       <p><div></p></div> -> <p><div><p></p></div>
+          // Chrome/FF say: <p><div></p></div> -> <p></p><div><p></p></div>.
+          // So that's cool.
+          var isEqualToOneOfThem =
+              proofElement.innerHTML === '<p><div><p></p></div>' ||
+              proofElement.innerHTML === '<p></p><div><p></p></div>';
+          expect(isEqualToOneOfThem).be.true;
+          expect(outputElement.innerHTML).to.include(escapeHTML('<p><div></p></div>'));
+        });
+      });
+
+    });
+
+    suite('<marked-element> without .markdown-html child', function() {
+
+      suite('respects camelCased HTML', function() {
         var markedElement;
         var proofElement;
 
         setup(function() {
-          markedElement = fixture('CamelCaseHTML');
+          markedElement = fixture('CamelCaseHTMLWithoutChild');
           proofElement = document.createElement('div');
         });
 
         test('in code blocks', function() {
           proofElement.innerHTML = '<div camelCase></div>';
+          expect(markedElement.$.content).to.equal(markedElement.outputElement);
+          expect(isHidden(markedElement.$.content)).to.be.false;
 
           // If Markdown content were put into a `<template>` or directly into the DOM, it would be
           // rendered as DOM and be converted from camelCase to lowercase per HTML parsing rules. By
@@ -84,22 +178,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-    suite('respsects bad HTML', function() {
+      suite('respects bad HTML', function() {
         var markedElement;
         var proofElement;
 
         setup(function() {
-          markedElement = fixture('BadHTML');
+          markedElement = fixture('BadHTMLWithoutChild');
           proofElement = document.createElement('div');
         });
 
         test('in code blocks', function() {
           proofElement.innerHTML = '<p><div></p></div>';
+          expect(markedElement.$.content).to.equal(markedElement.outputElement);
+          expect(isHidden(markedElement.$.content)).to.be.false;
 
           // If Markdown content were put into a `<template>` or directly into the DOM, it would be
           // rendered as DOM and close unbalanced tags. Because they are in code blocks they should
           // remain as typed.
-          expect(proofElement.innerHTML).to.eql('<p></p><div><p></p></div>');
+          // Turns out, however IE and everybody else have slightly different opinions
+          // about how the incorrect HTML should be fixed. It seems that:
+          // IE says:       <p><div></p></div> -> <p><div><p></p></div>
+          // Chrome/FF say: <p><div></p></div> -> <p></p><div><p></p></div>.
+          // So that's cool.
+          var isEqualToOneOfThem =
+              proofElement.innerHTML === '<p><div><p></p></div>' ||
+              proofElement.innerHTML === '<p></p><div><p></p></div>';
+          expect(isEqualToOneOfThem).be.true;
           expect(markedElement.$.content.innerHTML).to.include(escapeHTML('<p><div></p></div>'));
         });
       });


### PR DESCRIPTION
Currently, `<marked-element>` renders all its stuff to a child in the shadow DOM, which means that the output can't really be styled without `::shadow`, which is getting deprecated. 

To get around that, I added the option to render to a light child with a specific class. To not break any existing apps, we will still default to the shadow child if the `marked-output` child isn't provided, but at some point the shadow styling will probably break.

Dragons, man. Dragons everywhere.
