### PR TITLE
Expose callback function to element

### DIFF
--- a/marked-element.html
+++ b/marked-element.html
@@ -118,6 +118,15 @@ as you would a regular DOM element:
         observer: 'render',
         type: Boolean,
         value: false
+      },
+      /**
+       * Callback function invoked by Marked after HTML has been rendered.
+       * It must take two arguments: err and text and must return the resulting text.
+       */
+      callback: {
+        observer: 'render',
+        type: Function,
+        value: null
       }
     },
 
@@ -200,7 +209,7 @@ as you would a regular DOM element:
         pedantic: this.pedantic,
         smartypants: this.smartypants
       };
-      Polymer.dom(this._outputElement).innerHTML = marked(this.markdown, opts);
+      Polymer.dom(this._outputElement).innerHTML = marked(this.markdown, opts, this.callback);
       this.fire('marked-render-complete');
     },
 

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -86,6 +86,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="CustomCallbackFunction">
+    <template>
+      <marked-element>
+        <div id="output" class="markdown-html"></div>
+        <script type="text/markdown">
+          Some content
+        </script>
+      </marked-element>
+    </template>
+  </test-fixture>
+
   <script>
     'use strict';
 
@@ -121,7 +132,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
       test('has smartypants', function() {
         expect(markedElement.sanitize).to.equal(false);
-        console.log(outputElement.innerHTML)
+      });
+    });
+
+    suite('<marked-element> has some options of marked available', function( ){
+      var markedElement;
+      var proofElement;
+      var outputElement;
+      setup(function() {
+        markedElement = fixture('CustomCallbackFunction');
+        proofElement = document.createElement('div');
+        outputElement = document.getElementById('output');
+      });
+      test('calls callback after render', function() {
+        proofElement.innerHTML = '<div>Overridden!</div>'
+        markedElement.callback = function(err, text) {
+          assert.equal(text, '<p>Some content</p>\n');
+          return '<div>Overridden!</div>';
+        }
+        expect(outputElement.innerHTML).to.equal(proofElement.innerHTML);
       });
     });
 


### PR DESCRIPTION
This allows users to set custom callbacks to modify the outputted HTML. We use this in our project to modify GitHub issue references as follows:

``` html
<marked-element markdown="[[body]]" callback="[[callback(owner,name)]]"></marked-element>
```

``` js
callback: function(owner, name) {
  return function(err, text) {
    return text.replace(/&?#(\d+)/g, function(match, digits) {
      // Character was escaped, we should modify these numbers
      if (match.charAt(0) === '&') {
        return match;
      }
      return '<a href="https://www.github.com/' + owner + '/' + name + '/issues/' + digits + '" target="_blank">#' + digits + '</a>';
    });
  };
}
```
