### PR TITLE
Correct tests to match their description.

### DIFF
--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -128,10 +128,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(markedElement.sanitize).to.equal(false);
       });
       test('has pedantic', function() {
-        expect(markedElement.sanitize).to.equal(false);
+        expect(markedElement.pedantic).to.equal(false);
       });
       test('has smartypants', function() {
-        expect(markedElement.sanitize).to.equal(false);
+        expect(markedElement.smartypants).to.equal(true);
       });
     });
 


### PR DESCRIPTION
Looks like a copy paste bug. The descriptions were updated but the tests were left the same.
