### PR TITLE
Added renderer option.

### DIFF
--- a/marked-element.html
+++ b/marked-element.html
@@ -69,7 +69,7 @@ as you would a regular DOM element:
       :host {
         display: inline-block;
       }
-      
+
       /* Thanks IE 10. */
       .hidden {
         display: none !important;
@@ -106,6 +106,16 @@ as you would a regular DOM element:
         observer: 'render',
         type: Boolean,
         value: false
+      },
+      /**
+       * Function used to customize a renderer based on the [API specified in the Marked
+       * library](https://github.com/chjj/marked#overriding-renderer-methods).
+       * It takes one argument: a marked renderer object, which is mutated by the function.
+       */
+      renderer: {
+        observer: 'render',
+        type: Function,
+        value: null
       },
       /**
        * Sanitize the output. Ignore any HTML that has been input.
@@ -207,7 +217,12 @@ as you would a regular DOM element:
         Polymer.dom(this._outputElement).innerHTML = '';
         return;
       }
+      var renderer = new marked.Renderer();
+      if (this.renderer) {
+        this.renderer(renderer);
+      }
       var opts = {
+        renderer: renderer,
         highlight: this._highlight.bind(this),
         sanitize: this.sanitize,
         pedantic: this.pedantic,

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -86,6 +86,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="Renderer">
+    <template>
+      <marked-element>
+        <div id="output" class="markdown-html"></div>
+        <script type="text/markdown">
+          [Link](http://url.com)
+        </script>
+      </marked-element>
+    </template>
+  </test-fixture>
+
   <test-fixture id="CustomCallbackFunction">
     <template>
       <marked-element>
@@ -268,6 +279,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+    });
+
+    suite('<marked-element> with custom renderer', function() {
+      var markedElement;
+      var outputElement;
+      var proofElement;
+
+      setup(function() {
+        markedElement = fixture('Renderer');
+        outputElement = document.getElementById('output');
+        proofElement = document.createElement('div');
+      });
+
+      test('takes custom link renderer', function() {
+        markedElement.renderer = function (renderer) {
+          renderer.link = (href, title, text) => {
+            return `<a href="${href}" target="_blank">${text}</a>`;
+          };
+        };
+        proofElement.innerHTML = '<a href="http://url.com" target="_blank">Link</a>';
+        expect(outputElement.innerHTML).to.include(proofElement.innerHTML);
+      });
     });
 
     suite('events', function() {


### PR DESCRIPTION
Added to address #4 

Exposes the Marked API's option to pass in a customized renderer by allowing users to set the renderer attribute to a function that takes a renderer and customizes it. 