### PR TITLE
Expose marked's 'breaks' option to an attribute

### DIFF
--- a/marked-element.html
+++ b/marked-element.html
@@ -100,6 +100,14 @@ as you would a regular DOM element:
         value: null
       },
       /**
+       * Enable GFM line breaks (regular newlines instead of two spaces for breaks)
+       */
+      breaks: {
+        observer: 'render',
+        type: Boolean,
+        value: false
+      },
+      /**
        * Conform to obscure parts of markdown.pl as much as possible. Don't fix any of the original markdown bugs or poor behavior.
        */
       pedantic: {
@@ -224,6 +232,7 @@ as you would a regular DOM element:
       var opts = {
         renderer: renderer,
         highlight: this._highlight.bind(this),
+        breaks: this.breaks,
         sanitize: this.sanitize,
         pedantic: this.pedantic,
         smartypants: this.smartypants

--- a/test/marked-element.html
+++ b/test/marked-element.html
@@ -141,6 +141,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('has pedantic', function() {
         expect(markedElement.pedantic).to.equal(false);
       });
+      test('has breaks', function() {
+        expect(markedElement.breaks).to.equal(false);
+      });
       test('has smartypants', function() {
         expect(markedElement.smartypants).to.equal(true);
       });


### PR DESCRIPTION
Fixes #42 by creating a new attribute `breaks` which re-draws output if changed.

`breaks` is handed to marked during `render()` along with the rest of the options