### PR TITLE
Revert "Switch to using WCT directly"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ addons:
     packages:
       - google-chrome-beta
 before_script:
-  - npm install -g polymer-cli web-component-tester
+  - npm install -g polymer-cli
   - polymer install --variants
 script:
-  - xvfb-run wct
+  - xvfb-run polymer test
   - >-
-    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'default';
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
     fi
 env:
   global:


### PR DESCRIPTION
This reverts commit 947df07bdb98fe805c3f844d78d8ee3e90b05308.

Appears the upstream was fixed and should be good to revert this now. 

@e111077 