### PR TITLE
Bump marked version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "url": "git://github.com/PolymerElements/marked-element.git"
   },
   "dependencies": {
-    "marked": "~0.3.6",
+    "marked": "~0.3.9",
     "polymer": "Polymer/polymer#1.9 - 2"
   },
   "devDependencies": {
@@ -34,7 +34,7 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "marked": "~0.3.3",
+        "marked": "~0.3.9",
         "polymer": "Polymer/polymer#^1.9"
       },
       "devDependencies": {


### PR DESCRIPTION
The marked library was updated with a `0.3.9` version that fixes some XSS issues. This bumps to use that version to help close the hole.

@e111077 What do you think? 

