### PR TITLE
New: Use headless browsers for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 language: node_js
+dist: trusty
 sudo: required
 node_js: stable
 addons:
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-beta
+  chrome: stable
 before_script:
+  - polymer lint
+install:
   - npm install -g polymer-cli
   - polymer install --variants
 script:
-  - xvfb-run polymer test
+  - polymer test
   - >-
     if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
     fi
@@ -22,4 +21,6 @@ env:
         U0eSc8MeNqZ4XfBrG3qxHXiKK5iK/AQvaaip+xW1HhUehyD+Z4NRZ6EQ/dnVOBsrruZOTXb0bsz2VDzjB3dp1N9rEyQNbgbzL+KgkTqyyBEmY5JdnmAtTMPUCEdVkd8i+4Aqzwez4pFe3YeGUqqkhbF2YppRwPQ8W67iXc/veh8=
     - secure: >-
         NG1pVv8ehGHEY7Rx/86ADvdseqy8iCOod3sSGU3IbCO7NUhs8lpwtkbaUS75JvsqDBcSjlWK3tkw0iOa97/cP7O8pT2fgNfn3OLzoI7bgQCH7Qq5Am1fzdU+o/EfZuseOkxmnnuWATE+4mPP2JD3XOKvuuSAnRM6dipqRu3I0NA=
-dist: trusty
+cache:
+  directories:
+    - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 dist: trusty
-sudo: required
+sudo: false
 node_js: stable
 addons:
   firefox: latest

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "rules": ["polymer-2-hybrid"]
+  }
+}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,15 @@
+{
+  "plugins": {
+    "local": {
+      "browserOptions": {
+        "chrome": [
+          "headless",
+          "disable-gpu"
+        ],
+        "firefox": [
+          "-headless"
+        ]
+      }
+    }
+  }
+}

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -3,8 +3,7 @@
     "local": {
       "browserOptions": {
         "chrome": [
-          "headless",
-          "disable-gpu"
+          "headless"
         ],
         "firefox": [
           "-headless"

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -3,7 +3,9 @@
     "local": {
       "browserOptions": {
         "chrome": [
-          "headless"
+          "headless",
+          "disable-gpu",
+          "no-sandbox"
         ],
         "firefox": [
           "-headless"


### PR DESCRIPTION
Most of these changes are things that got merged into tedium PR (https://github.com/PolymerLabs/tedium/pull/58)

The new thing is that with WCT 6.5+ we can pass through arguments to the local browsers. This allows us to run headless. 

@azakus Would you prefer that we update Tedium to make these headless browser changes across the board?