### PR TITLE
Webpack support

### DIFF
--- a/marked-import.html
+++ b/marked-import.html
@@ -8,3 +8,10 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <script src='../marked/lib/marked.js'></script>
+<script>
+if (!window.marked) {
+  // For webpack support for the Polymer 3 version created by the Polymer Modulizer
+  // More info: https://github.com/PolymerElements/marked-element/issues/81
+  window.marked = require('../../marked/lib/marked.js');
+}
+</script>


### PR DESCRIPTION
See https://github.com/PolymerElements/marked-element/issues/81

Problem description: `marked` can detect that it is running inside webpack. In this case, it does not set its global variable. This PR sets this global variable manually, so that `<marked-element>` which expects the global variable to be set can find it.